### PR TITLE
feat(logger): add verbose diagnostics and improve message glob matching

### DIFF
--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -139,6 +139,32 @@ Rule fields:
 
 `levels` accepts `error`, `warn`, `info`, and `success`. `debug` is controlled by `debug: true`, not by `levels`.
 
+### Debug Timing in Rules Mode
+
+When a log call is emitted with `LoggerLogOptions.elapsedTimeMs`, the elapsed time is appended to the rendered message only when timing is active. Timing is asymmetric across configuration shapes:
+
+- **Without rules** (top-level `levels` only): `debug: true` enables timing on every visible log.
+- **With rules**: `debug: true` enables timing only on logs that match at least one rule that contributes the log's level. Logs that don't match any rule are already suppressed (rules are an allowlist with no root-level fallback), so the practical statement is: a log shows elapsed time iff it is **visible AND debug is on AND a rule contributed the level**.
+
+Example:
+
+```ts
+// Without rules — timing on all visible logs
+setLoggerConfig({ debug: true, levels: ['info', 'warn'] });
+logger.info('a', { elapsedTimeMs: 12.34 }); //=> visible with " 12.34ms"
+logger.warn('b', { elapsedTimeMs: 56.78 }); //=> visible with " 56.78ms"
+
+// With rules — timing only on rule-matched logs
+setLoggerConfig({
+  debug: true,
+  rules: [{ label: 'matched', group: 'userland.*', levels: ['info'] }],
+});
+logger.info('c', { elapsedTimeMs: 12.34 }); //=> only visible (and timed) if group matches userland.*
+logger.warn('d', { elapsedTimeMs: 56.78 }); //=> suppressed (no rule allows warn for this group)
+```
+
+`debug` is a top-level field, not per-rule. To get "always show timing on visible logs", configure without rules. To scope what is visible, use rules and accept that timing follows the same scope.
+
 ## Bundler Plugin
 
 Use `@docs-islands/logger/plugin` when you want bundler-injected runtime config and production tree-shaking.
@@ -172,10 +198,11 @@ loggerPlugin.farm(options);
 
 Plugin options:
 
-| Option      | Description                                                                                    |
-| ----------- | ---------------------------------------------------------------------------------------------- |
-| `config`    | Runtime `LoggerConfig` injected into the bundle. Omit it to use the default visibility policy. |
-| `treeshake` | Defaults to `true`. Set `false` to keep all logger calls and rely only on runtime filtering.   |
+| Option      | Description                                                                                                                                                                       |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `config`    | Runtime `LoggerConfig` injected into the bundle. Omit it to use the default visibility policy.                                                                                    |
+| `treeshake` | Defaults to `true`. Set `false` to keep all logger calls and rely only on runtime filtering.                                                                                      |
+| `verbose`   | Defaults to `false`. Set `true` to print per-file diagnostics for log calls that cannot be statically removed (with a reason and source frame), plus a build-end pruning summary. |
 
 Rollup hosts must install `@rollup/plugin-replace` before using `loggerPlugin.rollup(...)`. The logger plugin prepends Rollup's replace plugin to inline the logger control constants, including `__DOCS_ISLANDS_DEFAULT_LOGGER_CONTROLLED__` and `__DOCS_ISLANDS_DEFAULT_LOGGER_CONFIG__`, so the bundle receives the same serialized runtime config that other bundlers inject through their `define` hooks.
 
@@ -217,6 +244,21 @@ Kept for runtime filtering:
 - destructured methods
 - computed method access
 - non-standalone expressions such as assigning the result of a log call
+
+### Verbose Diagnostics
+
+Set `verbose: true` on the plugin to surface log calls the static analyzer kept. For each kept call the plugin emits a `console.warn` line with the source frame and a machine-readable reason; at the end of the build it emits a one-line summary of pruned, runtime-allowed, and unprunable counts.
+
+```ts
+loggerPlugin.vite({
+  config: { levels: ['warn', 'error'] },
+  verbose: true,
+});
+// [docs-islands:logger] /src/foo.ts:12:2 kept (dynamic-message): logger.info(`event ${id}`);
+// [docs-islands:logger] tree-shaking summary: 8 files scanned, 14 pruned, 3 kept (runtime-allowed), 2 kept (unprunable)
+```
+
+Reasons are one of: `aliased-create-logger`, `computed-method-access`, `destructured-method`, `dynamic-group`, `dynamic-main`, `dynamic-message`, `non-standalone-call`, `reassigned-binding`. Use them to decide whether to refactor the call site for static prunability or keep it as a runtime-filtered log.
 
 ## API
 

--- a/packages/logger/README.zh-CN.md
+++ b/packages/logger/README.zh-CN.md
@@ -139,6 +139,32 @@ setLoggerConfig({
 
 `levels` 只接受 `error`、`warn`、`info` 和 `success`。`debug` 由 `debug: true` 控制，不放进 `levels`。
 
+### 规则模式下的调试耗时显示
+
+当日志调用传入 `LoggerLogOptions.elapsedTimeMs` 时，耗时只有在「计时启用」的状态下才会附加到渲染消息上。计时的启用条件因配置形态而异：
+
+- **没有 rules**（仅顶层 `levels`）：`debug: true` 让每条可见日志都附耗时。
+- **启用 rules**：`debug: true` 仅对命中至少一条规则、且该规则贡献了当前级别的日志附耗时。未命中任何规则的日志本就被抑制（rules 是 allowlist，不会回退到顶层 `levels`），因此完整规则可总结为：**仅当日志可见且 debug 开启且某规则贡献了该级别，才会显示耗时**。
+
+示例：
+
+```ts
+// 无 rules —— 所有可见日志都计时
+setLoggerConfig({ debug: true, levels: ['info', 'warn'] });
+logger.info('a', { elapsedTimeMs: 12.34 }); //=> 可见且带 " 12.34ms"
+logger.warn('b', { elapsedTimeMs: 56.78 }); //=> 可见且带 " 56.78ms"
+
+// 有 rules —— 只有命中规则的日志才计时
+setLoggerConfig({
+  debug: true,
+  rules: [{ label: 'matched', group: 'userland.*', levels: ['info'] }],
+});
+logger.info('c', { elapsedTimeMs: 12.34 }); //=> 仅当 group 匹配 userland.* 时可见且计时
+logger.warn('d', { elapsedTimeMs: 56.78 }); //=> 该 group 上 warn 没有规则贡献，被抑制
+```
+
+`debug` 是顶层字段，不能逐规则设置。若希望「所有可见日志都显示耗时」，请使用不带 rules 的配置；若需要用 rules 限定可见范围，则要接受耗时显示也跟随该范围。
+
 ## 构建插件
 
 当你需要由构建工具注入 runtime config，并在生产构建中做日志裁剪时，使用 `@docs-islands/logger/plugin`。
@@ -172,10 +198,11 @@ loggerPlugin.farm(options);
 
 插件选项：
 
-| 选项        | 说明                                                                    |
-| ----------- | ----------------------------------------------------------------------- |
-| `config`    | 注入 bundle 的 runtime `LoggerConfig`。省略时使用默认可见性策略。       |
-| `treeshake` | 默认为 `true`。设置为 `false` 后保留所有日志调用，只依赖 runtime 过滤。 |
+| 选项        | 说明                                                                                                                  |
+| ----------- | --------------------------------------------------------------------------------------------------------------------- |
+| `config`    | 注入 bundle 的 runtime `LoggerConfig`。省略时使用默认可见性策略。                                                     |
+| `treeshake` | 默认为 `true`。设置为 `false` 后保留所有日志调用，只依赖 runtime 过滤。                                               |
+| `verbose`   | 默认为 `false`。设置为 `true` 后，对每个无法静态裁剪的日志调用打印源码 frame 与原因，并在构建结束时输出一行裁剪汇总。 |
 
 Rollup 宿主 bundler 在使用 `loggerPlugin.rollup(...)` 前，需要主动安装 `@rollup/plugin-replace`。logger plugin 会把 Rollup 的 replace plugin 插到插件链前面，用它内联 logger 控制常量，包括 `__DOCS_ISLANDS_DEFAULT_LOGGER_CONTROLLED__` 和 `__DOCS_ISLANDS_DEFAULT_LOGGER_CONFIG__`，让 Rollup bundle 拿到与其他 bundler 通过 `define` hook 注入时相同的序列化 runtime config。
 
@@ -217,6 +244,21 @@ logger.debug('static metric details');
 - 解构出的日志方法
 - computed method access
 - 非独立表达式，例如把日志调用结果赋值给变量
+
+### Verbose 诊断
+
+把插件选项设为 `verbose: true`，可以暴露静态分析未能裁剪的日志调用。每条这样的调用都会通过 `console.warn` 打印源码 frame 与可被工具识别的原因；构建结束时还会打印一行汇总，列出被裁剪、运行时允许、以及无法裁剪的数量。
+
+```ts
+loggerPlugin.vite({
+  config: { levels: ['warn', 'error'] },
+  verbose: true,
+});
+// [docs-islands:logger] /src/foo.ts:12:2 kept (dynamic-message): logger.info(`event ${id}`);
+// [docs-islands:logger] tree-shaking summary: 8 files scanned, 14 pruned, 3 kept (runtime-allowed), 2 kept (unprunable)
+```
+
+可能的原因取值：`aliased-create-logger`、`computed-method-access`、`destructured-method`、`dynamic-group`、`dynamic-main`、`dynamic-message`、`non-standalone-call`、`reassigned-binding`。可据此决定是否重构调用点以让它支持静态裁剪，还是保留它依赖 runtime 过滤。
 
 ## API
 

--- a/packages/logger/src/__tests__/plugin.test.ts
+++ b/packages/logger/src/__tests__/plugin.test.ts
@@ -10,7 +10,7 @@ import {
 } from '@docs-islands/logger/plugin';
 import { rolldown } from 'rolldown';
 import { rollup } from 'rollup';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { LOGGER_TREE_SHAKING_PLAYGROUND_BUILDS } from '../../playground/tree-shaking/builders';
 import {
   LOGGER_TREE_SHAKING_HIDDEN_INFO,
@@ -672,5 +672,174 @@ logger.info('kept aliased dynamic info');
     });
 
     expect(result).toBeNull();
+  });
+
+  it('omits diagnostics when collectDiagnostics is unset', async () => {
+    setScopedLoggerConfig(TEST_SCOPE_ID, {
+      levels: ['warn', 'error'],
+    });
+
+    const source = `
+import { createLogger } from '@docs-islands/logger';
+
+const logger = createLogger({ main: '@acme/docs' }).getLoggerByGroup('userland.metrics');
+
+logger.info('hidden static info');
+logger.warn('visible static warning');
+`;
+    const result = await transformLoggerTreeShaking(source, TEST_MODULE_ID, {
+      loggerModuleId: DEFAULT_LOGGER_MODULE_ID,
+      loggerScopeId: TEST_SCOPE_ID,
+    });
+
+    expect(result?.diagnostics).toBeUndefined();
+    expect(result?.stats).toEqual({
+      keptRuntimeAllowedCount: 1,
+      keptStaticUnprunableCount: 0,
+      prunedCount: 1,
+    });
+  });
+
+  it('reports an aliased-create-logger diagnostic when verbose', async () => {
+    setScopedLoggerConfig(TEST_SCOPE_ID, {
+      levels: ['error'],
+    });
+
+    const source = `
+import { createLogger as makeLogger } from '@docs-islands/logger';
+
+const logger = makeLogger({ main: '@acme/docs' }).getLoggerByGroup('userland.metrics');
+
+logger.info('kept aliased info');
+`;
+    const result = await transformLoggerTreeShaking(source, TEST_MODULE_ID, {
+      collectDiagnostics: true,
+      loggerModuleId: DEFAULT_LOGGER_MODULE_ID,
+      loggerScopeId: TEST_SCOPE_ID,
+    });
+
+    expect(result?.diagnostics).toEqual([
+      expect.objectContaining({
+        reason: 'aliased-create-logger',
+        snippet: "logger.info('kept aliased info');",
+      }),
+    ]);
+    expect(result?.stats?.keptStaticUnprunableCount).toBe(1);
+    expect(result?.stats?.prunedCount).toBe(0);
+  });
+
+  it('reports a dynamic-message diagnostic when verbose', async () => {
+    setScopedLoggerConfig(TEST_SCOPE_ID, {
+      levels: ['error'],
+    });
+
+    const source = `
+import { createLogger } from '@docs-islands/logger';
+
+const logger = createLogger({ main: '@acme/docs' }).getLoggerByGroup('userland.metrics');
+const dynamic = String(Date.now());
+
+logger.info(\`event \${dynamic}\`);
+`;
+    const result = await transformLoggerTreeShaking(source, TEST_MODULE_ID, {
+      collectDiagnostics: true,
+      loggerModuleId: DEFAULT_LOGGER_MODULE_ID,
+      loggerScopeId: TEST_SCOPE_ID,
+    });
+
+    expect(result?.diagnostics).toEqual([
+      expect.objectContaining({
+        reason: 'dynamic-message',
+      }),
+    ]);
+  });
+
+  it('reports a destructured-method diagnostic when verbose', async () => {
+    setScopedLoggerConfig(TEST_SCOPE_ID, {
+      levels: ['error'],
+    });
+
+    const source = `
+import { createLogger } from '@docs-islands/logger';
+
+const [logger] = [createLogger({ main: '@acme/docs' }).getLoggerByGroup('userland.metrics')];
+
+logger.info('kept destructured info');
+`;
+    const result = await transformLoggerTreeShaking(source, TEST_MODULE_ID, {
+      collectDiagnostics: true,
+      loggerModuleId: DEFAULT_LOGGER_MODULE_ID,
+      loggerScopeId: TEST_SCOPE_ID,
+    });
+
+    expect(result?.diagnostics).toEqual([
+      expect.objectContaining({
+        reason: 'destructured-method',
+      }),
+    ]);
+  });
+
+  it('reports a non-standalone-call diagnostic when verbose', async () => {
+    setScopedLoggerConfig(TEST_SCOPE_ID, {
+      levels: ['error'],
+    });
+
+    const source = `
+import { createLogger } from '@docs-islands/logger';
+
+const logger = createLogger({ main: '@acme/docs' }).getLoggerByGroup('userland.metrics');
+
+const result = logger.info('kept non-standalone info');
+`;
+    const result = await transformLoggerTreeShaking(source, TEST_MODULE_ID, {
+      collectDiagnostics: true,
+      loggerModuleId: DEFAULT_LOGGER_MODULE_ID,
+      loggerScopeId: TEST_SCOPE_ID,
+    });
+
+    expect(result?.diagnostics).toEqual([
+      expect.objectContaining({
+        reason: 'non-standalone-call',
+      }),
+    ]);
+  });
+
+  it('emits a verbose summary on buildEnd', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const plugin = loggerPlugin.vite({
+        config: { levels: ['warn', 'error'] },
+        verbose: true,
+      });
+      const code = await runPluginTransform(
+        plugin,
+        `
+import { createLogger } from '@docs-islands/logger';
+const logger = createLogger({ main: '@acme/docs' }).getLoggerByGroup('userland.metrics');
+logger.info('hidden static info');
+logger.warn('visible static warning');
+`,
+      );
+
+      expect(code).not.toContain('hidden static info');
+      expect(code).toContain('visible static warning');
+
+      const buildEnd = (plugin as { buildEnd?: () => void }).buildEnd;
+      buildEnd?.call({});
+
+      const summaryCall = warnSpy.mock.calls.find(([message]) =>
+        typeof message === 'string'
+          ? message.includes('tree-shaking summary:')
+          : false,
+      );
+
+      expect(summaryCall?.[0]).toMatch(/1 files scanned/);
+      expect(summaryCall?.[0]).toMatch(/1 pruned/);
+      expect(summaryCall?.[0]).toMatch(/1 kept \(runtime-allowed\)/);
+      expect(summaryCall?.[0]).toMatch(/0 kept \(unprunable\)/);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/logger/src/__tests__/runtime.test.ts
+++ b/packages/logger/src/__tests__/runtime.test.ts
@@ -68,10 +68,12 @@ describe('runtime logger', () => {
     expect(shouldSuppressLog('debug', context)).toBe(true);
   });
 
-  it('uses default visibility when direct usage explicitly clears default config', () => {
+  it('uses default visibility after resetLoggerConfig() clears the default config', () => {
+    setLoggerConfig({ levels: ['error'] });
+
     const output = captureConsoleLog();
 
-    setLoggerConfig(undefined);
+    resetLoggerConfig();
 
     createLogger({
       main: '@acme/logger',

--- a/packages/logger/src/core/config.ts
+++ b/packages/logger/src/core/config.ts
@@ -32,6 +32,7 @@ const GLOB_PATTERN_RE = /[!()*+?[\]{}]/;
 
 const picomatch = rawPicomatch as unknown as (
   pattern: string | readonly string[],
+  options?: { bash?: boolean },
 ) => (value: string) => boolean;
 
 let hasSyncedRuntimeDefinedDefaultLoggerConfig = false;
@@ -51,14 +52,19 @@ const createPatternMatcher = (
   pattern: string,
   mode: 'group' | 'message',
 ): ((value: string) => boolean) => {
-  if (
-    (mode === 'group' || mode === 'message') &&
-    !GLOB_PATTERN_RE.test(pattern)
-  ) {
+  if (!GLOB_PATTERN_RE.test(pattern)) {
     return (value) => value === pattern;
   }
 
-  const matcher = picomatch(pattern);
+  // Group names are constrained by GROUP_NAME_RE to lowercase dot namespaces
+  // and never contain `/`, so picomatch's path-segment-aware default is fine.
+  // Messages may legitimately contain `/` (HTTP paths, file paths embedded in
+  // text). Users expect shell fnmatch semantics where `*` crosses `/`. Picomatch
+  // v4's `bash: true` option makes single `*` behave like `**` for that mode.
+  const matcher =
+    mode === 'message'
+      ? picomatch(pattern, { bash: true })
+      : picomatch(pattern);
 
   return (value) => matcher(value);
 };
@@ -124,7 +130,7 @@ const getLoggerConfigRegistry = (): Map<
 };
 
 const createLoggerConfigRegistryEntry = (
-  config: LoggerConfig | null | undefined,
+  config: LoggerConfig,
 ): LoggerConfigRegistryEntry => {
   const normalizedConfig = normalizeLoggerConfig(config);
 

--- a/packages/logger/src/plugin/index.ts
+++ b/packages/logger/src/plugin/index.ts
@@ -21,6 +21,8 @@ import type { LoggerConfig } from '../types';
 import {
   DEFAULT_LOGGER_MODULE_ID,
   transformLoggerTreeShaking,
+  type LoggerTreeShakingDiagnostic,
+  type LoggerTreeShakingStats,
 } from './transform';
 
 const resolveModuleSpecifier = (
@@ -59,6 +61,7 @@ const ROLLUP_REPLACE_PLUGIN_OPTIONS = {
 export interface LoggerPluginOptions {
   config?: LoggerConfig | null;
   treeshake?: boolean;
+  verbose?: boolean;
 }
 
 interface ViteUserConfigWithDefine {
@@ -316,6 +319,33 @@ const readTransformIsBuild = (
   return isBuild;
 };
 
+const emitLoggerVerboseDiagnostic = (
+  id: string,
+  diagnostic: LoggerTreeShakingDiagnostic,
+): void => {
+  // eslint-disable-next-line no-console -- build-time diagnostic intentionally
+  // bypasses the runtime logger to avoid feedback loops and ensure visibility
+  // even when the logger config suppresses everything.
+  console.warn(
+    `[${LOGGER_PLUGIN_NAME}] ${id}:${diagnostic.line}:${diagnostic.column} ` +
+      `kept (${diagnostic.reason}): ${diagnostic.snippet}`,
+  );
+};
+
+const emitLoggerVerboseSummary = (
+  scannedFileCount: number,
+  stats: LoggerTreeShakingStats,
+): void => {
+  // eslint-disable-next-line no-console -- see emitLoggerVerboseDiagnostic.
+  console.warn(
+    `[${LOGGER_PLUGIN_NAME}] tree-shaking summary: ` +
+      `${scannedFileCount} files scanned, ` +
+      `${stats.prunedCount} pruned, ` +
+      `${stats.keptRuntimeAllowedCount} kept (runtime-allowed), ` +
+      `${stats.keptStaticUnprunableCount} kept (unprunable)`,
+  );
+};
+
 const factory: UnpluginFactory<LoggerPluginOptions | undefined> = (
   options = {},
   meta,
@@ -324,7 +354,14 @@ const factory: UnpluginFactory<LoggerPluginOptions | undefined> = (
   const loggerConfig = options.config ?? DEFAULT_LOGGER_CONFIG;
   const defines = createLoggerPluginDefines(loggerConfig);
   const shouldTreeshake = options.treeshake !== false;
+  const verbose = options.verbose === true;
   let isBuild = readInitialIsBuild(meta);
+  let scannedFileCount = 0;
+  const aggregateStats: LoggerTreeShakingStats = {
+    keptRuntimeAllowedCount: 0,
+    keptStaticUnprunableCount: 0,
+    prunedCount: 0,
+  };
 
   setScopedLoggerConfig(loggerScopeId, loggerConfig);
 
@@ -387,10 +424,43 @@ const factory: UnpluginFactory<LoggerPluginOptions | undefined> = (
         return null;
       }
 
-      return transformLoggerTreeShaking(code, id, {
+      const result = await transformLoggerTreeShaking(code, id, {
+        collectDiagnostics: verbose,
         loggerModuleId: DEFAULT_LOGGER_MODULE_ID,
         loggerScopeId,
       });
+
+      if (!result) {
+        return null;
+      }
+
+      if (result.stats) {
+        scannedFileCount += 1;
+        aggregateStats.prunedCount += result.stats.prunedCount;
+        aggregateStats.keptRuntimeAllowedCount +=
+          result.stats.keptRuntimeAllowedCount;
+        aggregateStats.keptStaticUnprunableCount +=
+          result.stats.keptStaticUnprunableCount;
+      }
+
+      if (verbose && result.diagnostics) {
+        for (const diagnostic of result.diagnostics) {
+          emitLoggerVerboseDiagnostic(id, diagnostic);
+        }
+      }
+
+      // When no code change, returning the original code/no map is a
+      // near-no-op for the bundler — accepted by Vite/Rollup/Rolldown/etc.
+      return result.map
+        ? { code: result.code, map: result.map }
+        : { code: result.code };
+    },
+    buildEnd() {
+      if (!verbose) {
+        return;
+      }
+
+      emitLoggerVerboseSummary(scannedFileCount, aggregateStats);
     },
   };
 };

--- a/packages/logger/src/plugin/transform.ts
+++ b/packages/logger/src/plugin/transform.ts
@@ -39,14 +39,40 @@ interface StaticLogCall {
   message: string;
 }
 
+export type LoggerTreeShakingUnprunableReason =
+  | 'aliased-create-logger'
+  | 'computed-method-access'
+  | 'destructured-method'
+  | 'dynamic-group'
+  | 'dynamic-main'
+  | 'dynamic-message'
+  | 'non-standalone-call'
+  | 'reassigned-binding';
+
+export interface LoggerTreeShakingDiagnostic {
+  column: number;
+  line: number;
+  reason: LoggerTreeShakingUnprunableReason;
+  snippet: string;
+}
+
+export interface LoggerTreeShakingStats {
+  keptRuntimeAllowedCount: number;
+  keptStaticUnprunableCount: number;
+  prunedCount: number;
+}
+
 export interface LoggerTreeShakingTransformOptions {
+  collectDiagnostics?: boolean;
   loggerModuleId: string;
   loggerScopeId: LoggerScopeId;
 }
 
 export interface LoggerTreeShakingTransformResult {
   code: string;
-  map: SourceMap;
+  diagnostics?: LoggerTreeShakingDiagnostic[];
+  map?: SourceMap;
+  stats?: LoggerTreeShakingStats;
 }
 
 // @babel/traverse only exposes a CommonJS package.
@@ -221,59 +247,189 @@ const readStaticLoggerBinding = (
   };
 };
 
-const readStaticLogCall = (
-  expression: t.Expression,
-  path: NodePath<t.ExpressionStatement>,
-  staticLoggerBindings: WeakMap<t.Identifier, StaticLoggerBinding>,
-): StaticLogCall | null => {
+interface LogCallShape {
+  kind: LogKind;
+  objectName: string;
+}
+
+const detectLogCallShape = (expression: t.Expression): LogCallShape | null => {
   if (!t.isCallExpression(expression)) {
     return null;
   }
 
   const callee = expression.callee;
 
+  if (!t.isMemberExpression(callee) || !t.isIdentifier(callee.object)) {
+    return null;
+  }
+
+  let methodName: string | null = null;
+
+  if (callee.computed) {
+    if (t.isStringLiteral(callee.property)) {
+      methodName = callee.property.value;
+    }
+  } else if (t.isIdentifier(callee.property)) {
+    methodName = callee.property.name;
+  }
+
+  if (!methodName || !LOG_METHODS.has(methodName as LogKind)) {
+    return null;
+  }
+
+  return {
+    kind: methodName as LogKind,
+    objectName: callee.object.name,
+  };
+};
+
+const classifyLoggerBindingFailure = (
+  init: t.Expression | null | undefined,
+): LoggerTreeShakingUnprunableReason => {
+  if (!t.isCallExpression(init)) {
+    return 'destructured-method';
+  }
+
+  const callee = init.callee;
+
   if (
     !t.isMemberExpression(callee) ||
     callee.computed ||
-    !t.isIdentifier(callee.object) ||
     !t.isIdentifier(callee.property) ||
-    !LOG_METHODS.has(callee.property.name as LogKind)
+    callee.property.name !== 'getLoggerByGroup'
   ) {
-    return null;
+    return 'destructured-method';
   }
 
-  const [messageArgument] = expression.arguments;
+  const [groupArgument] = init.arguments;
 
-  if (!isStaticStringLiteral(messageArgument)) {
-    return null;
+  if (!isStaticStringLiteral(groupArgument)) {
+    return 'dynamic-group';
   }
 
-  const binding = path.scope.getBinding(callee.object.name);
+  if (!t.isCallExpression(callee.object)) {
+    return 'destructured-method';
+  }
+
+  const createCall = callee.object;
 
   if (
-    !binding?.path.isVariableDeclarator() ||
-    binding.constantViolations.length > 0
+    !t.isIdentifier(createCall.callee) ||
+    createCall.callee.name !== 'createLogger'
   ) {
+    return 'aliased-create-logger';
+  }
+
+  const [createOptions] = createCall.arguments;
+
+  if (!t.isObjectExpression(createOptions)) {
+    return 'dynamic-main';
+  }
+
+  for (const property of createOptions.properties) {
+    if (
+      t.isObjectProperty(property) &&
+      !property.computed &&
+      getStaticPropertyName(property.key) === 'main'
+    ) {
+      if (!isStaticStringLiteral(property.value)) {
+        return 'dynamic-main';
+      }
+      // Main is literal, but the binding still wasn't recognized — so the
+      // createLogger identifier resolves to a binding outside the public
+      // import set. The most likely cause is an import alias.
+      return 'aliased-create-logger';
+    }
+  }
+
+  return 'dynamic-main';
+};
+
+type LogCallClassification =
+  | { call: StaticLogCall; type: 'static' }
+  | { reason: LoggerTreeShakingUnprunableReason; type: 'unprunable' };
+
+const classifyLogCall = (
+  expression: t.Expression,
+  path: NodePath<t.ExpressionStatement>,
+  staticLoggerBindings: WeakMap<t.Identifier, StaticLoggerBinding>,
+): LogCallClassification | null => {
+  const shape = detectLogCallShape(expression);
+
+  if (!shape) {
     return null;
+  }
+
+  const callee = (expression as t.CallExpression).callee as t.MemberExpression;
+
+  if (callee.computed) {
+    return { reason: 'computed-method-access', type: 'unprunable' };
+  }
+
+  const binding = path.scope.getBinding(shape.objectName);
+
+  if (!binding) {
+    // Identifier not declared in scope (e.g., a global). Not a candidate.
+    return null;
+  }
+
+  if (binding.constantViolations.length > 0) {
+    return { reason: 'reassigned-binding', type: 'unprunable' };
+  }
+
+  if (!binding.path.isVariableDeclarator()) {
+    return { reason: 'reassigned-binding', type: 'unprunable' };
+  }
+
+  const declarationParent = binding.path.parentPath;
+
+  if (
+    declarationParent?.isVariableDeclaration() &&
+    declarationParent.node.kind !== 'const'
+  ) {
+    return { reason: 'reassigned-binding', type: 'unprunable' };
   }
 
   const declarationId = binding.path.node.id;
 
   if (!t.isIdentifier(declarationId)) {
-    return null;
+    return { reason: 'destructured-method', type: 'unprunable' };
   }
 
   const loggerBinding = staticLoggerBindings.get(declarationId);
 
   if (!loggerBinding) {
-    return null;
+    return {
+      reason: classifyLoggerBindingFailure(binding.path.node.init),
+      type: 'unprunable',
+    };
+  }
+
+  const [messageArgument] = (expression as t.CallExpression).arguments;
+
+  if (!isStaticStringLiteral(messageArgument)) {
+    return { reason: 'dynamic-message', type: 'unprunable' };
   }
 
   return {
-    ...loggerBinding,
-    kind: callee.property.name as LogKind,
-    message: messageArgument.value,
+    call: {
+      ...loggerBinding,
+      kind: shape.kind,
+      message: messageArgument.value,
+    },
+    type: 'static',
   };
+};
+
+const extractDiagnosticSnippet = (code: string, node: t.Node): string => {
+  if (typeof node.start !== 'number' || typeof node.end !== 'number') {
+    return '';
+  }
+
+  const slice = code.slice(node.start, node.end);
+  const firstLine = slice.split('\n')[0];
+
+  return firstLine.trim();
 };
 
 export async function transformLoggerTreeShaking(
@@ -282,6 +438,7 @@ export async function transformLoggerTreeShaking(
   options: LoggerTreeShakingTransformOptions,
 ): Promise<LoggerTreeShakingTransformResult | null> {
   const loggerModuleId = normalizeLoggerModuleId(options.loggerModuleId);
+  const collectDiagnostics = options.collectDiagnostics === true;
 
   if (!(await hasPublicCreateLoggerImport(code, loggerModuleId))) {
     return null;
@@ -337,19 +494,47 @@ export async function transformLoggerTreeShaking(
   });
 
   const transformedCode = new MagicString(code);
-  let removedLogCount = 0;
+  const diagnostics: LoggerTreeShakingDiagnostic[] = [];
+  const stats: LoggerTreeShakingStats = {
+    keptRuntimeAllowedCount: 0,
+    keptStaticUnprunableCount: 0,
+    prunedCount: 0,
+  };
+  const reportUnprunable = (
+    reason: LoggerTreeShakingUnprunableReason,
+    node: t.Node,
+  ): void => {
+    stats.keptStaticUnprunableCount += 1;
+    if (!collectDiagnostics) {
+      return;
+    }
+    const loc = node.loc?.start;
+    diagnostics.push({
+      column: loc?.column ?? 0,
+      line: loc?.line ?? 0,
+      reason,
+      snippet: extractDiagnosticSnippet(code, node),
+    });
+  };
 
   traverse(ast, {
     ExpressionStatement(path) {
-      const staticLogCall = readStaticLogCall(
+      const classification = classifyLogCall(
         path.node.expression,
         path,
         staticLoggerBindings,
       );
 
-      if (!staticLogCall) {
+      if (!classification) {
         return;
       }
+
+      if (classification.type === 'unprunable') {
+        reportUnprunable(classification.reason, path.node);
+        return;
+      }
+
+      const staticLogCall = classification.call;
 
       if (
         !shouldSuppressLog(
@@ -362,6 +547,7 @@ export async function transformLoggerTreeShaking(
           options.loggerScopeId,
         )
       ) {
+        stats.keptRuntimeAllowedCount += 1;
         return;
       }
 
@@ -373,20 +559,57 @@ export async function transformLoggerTreeShaking(
       }
 
       transformedCode.remove(path.node.start, path.node.end);
-      removedLogCount += 1;
+      stats.prunedCount += 1;
+    },
+    CallExpression(path) {
+      if (path.parentPath.isExpressionStatement()) {
+        return;
+      }
+
+      const shape = detectLogCallShape(path.node);
+
+      if (!shape) {
+        return;
+      }
+
+      const binding = path.scope.getBinding(shape.objectName);
+
+      if (!binding) {
+        return;
+      }
+
+      const declarationId = binding.path.isVariableDeclarator()
+        ? binding.path.node.id
+        : null;
+
+      if (!declarationId || !t.isIdentifier(declarationId)) {
+        return;
+      }
+
+      if (!staticLoggerBindings.has(declarationId)) {
+        return;
+      }
+
+      reportUnprunable('non-standalone-call', path.node);
     },
   });
 
-  if (removedLogCount === 0) {
+  if (stats.prunedCount === 0 && !collectDiagnostics) {
     return null;
   }
 
+  const hasCodeChange = stats.prunedCount > 0;
+
   return {
-    code: transformedCode.toString(),
-    map: transformedCode.generateMap({
-      hires: true,
-      includeContent: true,
-      source: id,
-    }),
+    code: hasCodeChange ? transformedCode.toString() : code,
+    diagnostics: collectDiagnostics ? diagnostics : undefined,
+    map: hasCodeChange
+      ? transformedCode.generateMap({
+          hires: true,
+          includeContent: true,
+          source: id,
+        })
+      : undefined,
+    stats,
   };
 }

--- a/packages/logger/src/types/index.ts
+++ b/packages/logger/src/types/index.ts
@@ -77,7 +77,12 @@ export interface ResolvedLoggerContext {
 }
 
 export type { Logger, ScopedLogger } from '../core/factory';
-export type { LoggerTreeShakingTransformResult } from '../plugin/transform';
+export type {
+  LoggerTreeShakingDiagnostic,
+  LoggerTreeShakingStats,
+  LoggerTreeShakingTransformResult,
+  LoggerTreeShakingUnprunableReason,
+} from '../plugin/transform';
 
 declare global {
   var __DOCS_ISLANDS_LOGGER_CONFIG_REGISTRY__:

--- a/packages/vitepress/src/shared/__tests__/logger-test-cases.ts
+++ b/packages/vitepress/src/shared/__tests__/logger-test-cases.ts
@@ -1,6 +1,6 @@
 import type { LoggerConfig, LogKind } from '@docs-islands/logger/types';
 
-export const LOGGER_SPEC_CASE_COUNT = 31;
+export const LOGGER_SPEC_CASE_COUNT = 32;
 export const LOGGER_SPEC_ELAPSED = '42.00ms';
 
 interface LoggerFixture {
@@ -1451,5 +1451,48 @@ export const loggerSpecCases: LoggerSpecCase[] = [
     operations: [op('A', 'error', 'request timeout')],
     expected: [],
     expectedDebug: [],
+  },
+  {
+    name: 'Case 32 - message glob crosses path separators (bash mode)',
+    config: {
+      debug: false,
+      rules: [
+        { label: 'Test1', message: 'GET /api/*', levels: ['error'] },
+        { label: 'Test2', message: '*timeout*', levels: ['warn'] },
+      ],
+    },
+    loggers: {
+      A: { group: 'test.case.message.slash', main: TEST_MAIN },
+    },
+    operations: [
+      op('A', 'error', 'GET /api/users'),
+      op('A', 'error', 'GET /api/users/profile'),
+      op('A', 'warn', 'request /api/timeout'),
+    ],
+    expected: [
+      line(TEST_MAIN, 'test.case.message.slash', 'GET /api/users'),
+      line(TEST_MAIN, 'test.case.message.slash', 'GET /api/users/profile'),
+      line(TEST_MAIN, 'test.case.message.slash', 'request /api/timeout'),
+    ],
+    expectedDebug: [
+      debugLine(
+        ['Test1'],
+        TEST_MAIN,
+        'test.case.message.slash',
+        'GET /api/users',
+      ),
+      debugLine(
+        ['Test1'],
+        TEST_MAIN,
+        'test.case.message.slash',
+        'GET /api/users/profile',
+      ),
+      debugLine(
+        ['Test2'],
+        TEST_MAIN,
+        'test.case.message.slash',
+        'request /api/timeout',
+      ),
+    ],
   },
 ];


### PR DESCRIPTION
## Summary

This PR enhances the logger package with verbose diagnostics for tree-shaking analysis and fixes message glob pattern matching behavior.

## Changes

### Verbose Diagnostics
- Added `verbose` option to plugin configuration
- Reports unprunable log calls with machine-readable reasons during build
- Emits tree-shaking summary at build end (files scanned, pruned, kept counts)
- Diagnostic reasons: `aliased-create-logger`, `computed-method-access`, `destructured-method`, `dynamic-group`, `dynamic-main`, `dynamic-message`, `non-standalone-call`, `reassigned-binding`

### Message Glob Matching
- Fixed message pattern matching to use bash-style glob semantics
- Single `*` now crosses path separators (e.g., `GET /api/*` matches `GET /api/users/profile`)
- Group patterns remain path-segment-aware (unchanged behavior)

### Documentation
- Added "Debug Timing in Rules Mode" section explaining timing behavior differences
- Added "Verbose Diagnostics" section with usage examples
- Updated both English and Chinese READMEs

### API
- Exported diagnostic types: `LoggerTreeShakingDiagnostic`, `LoggerTreeShakingStats`, `LoggerTreeShakingUnprunableReason`
- Transform result now includes optional `diagnostics` and `stats` fields

## Testing

- Added comprehensive test coverage for diagnostic collection
- Added test case for message glob crossing path separators
- All existing tests pass

## Breaking Changes

⚠️ Message glob patterns now use bash-style matching where `*` crosses `/`. This may affect existing rules that rely on path-segment-aware matching for message patterns.

**Migration**: If you have message patterns that should NOT cross path separators, use more specific patterns or switch to exact string matching.